### PR TITLE
feat: Upgrade demo to use mobile input

### DIFF
--- a/index.html
+++ b/index.html
@@ -7,9 +7,47 @@
 <style>
   body { margin: 0; overflow: hidden; }
   canvas { display: block; width: 100vw; height: 100vh; }
+  #joystick {
+    position: absolute;
+    bottom: 20px;
+    left: 20px;
+    width: 100px;
+    height: 100px;
+    background: rgba(0, 0, 0, 0.2);
+    border-radius: 50%;
+  }
+
+  #joystick-handle {
+    position: absolute;
+    top: 25px;
+    left: 25px;
+    width: 50px;
+    height: 50px;
+    background: rgba(0, 0, 0, 0.5);
+    border-radius: 50%;
+  }
+
+  #jump-button {
+    position: absolute;
+    bottom: 20px;
+    right: 20px;
+    width: 80px;
+    height: 80px;
+    background: rgba(0, 0, 0, 0.5);
+    border-radius: 50%;
+    color: white;
+    font-size: 24px;
+    text-align: center;
+    line-height: 80px;
+    cursor: pointer;
+  }
 </style>
 </head>
 <body>
     <script type="module" src="main.js"></script>
+    <div id="joystick">
+        <div id="joystick-handle"></div>
+    </div>
+    <div id="jump-button">Jump</div>
 </body>
 </html>

--- a/main.js
+++ b/main.js
@@ -366,8 +366,8 @@ window.addEventListener('load', async () => {
             joystickHandle.style.left = `${joystickRect.width / 2 + Math.cos(angle) * distance - joystickHandle.offsetWidth / 2}px`;
             joystickHandle.style.top = `${joystickRect.height / 2 + Math.sin(angle) * distance - joystickHandle.offsetHeight / 2}px`;
 
-            mobileInputSystem.inputs.pan.x = (Math.cos(angle) * distance) * 2;
-            mobileInputSystem.inputs.pan.y = (Math.sin(angle) * distance) * 2;
+            mobileInputSystem.inputs.pan.x = (Math.cos(angle) * distance) * PAN_MULTIPLIER;
+            mobileInputSystem.inputs.pan.y = (Math.sin(angle) * distance) * PAN_MULTIPLIER;
         }
     };
 

--- a/main.js
+++ b/main.js
@@ -373,8 +373,10 @@ window.addEventListener('load', async () => {
 
     const handleUp = () => {
         dragging = false;
-        joystickHandle.style.left = `${joystickRect.width / 2 - joystickHandle.offsetWidth / 2}px`;
-        joystickHandle.style.top = `${joystickRect.height / 2 - joystickHandle.offsetHeight / 2}px`;
+        if (joystickRect) {
+            joystickHandle.style.left = `${joystickRect.width / 2 - joystickHandle.offsetWidth / 2}px`;
+            joystickHandle.style.top = `${joystickRect.height / 2 - joystickHandle.offsetHeight / 2}px`;
+        }
         mobileInputSystem.inputs.pan.x = 0;
         mobileInputSystem.inputs.pan.y = 0;
     };

--- a/main.js
+++ b/main.js
@@ -342,6 +342,51 @@ class Game {
 window.addEventListener('load', async () => {
     const game = new Game();
     await game.init();
+
+    const joystick = document.getElementById('joystick');
+    const joystickHandle = document.getElementById('joystick-handle');
+    const joystickRect = joystick.getBoundingClientRect();
+    let dragging = false;
+
+    joystickHandle.addEventListener('mousedown', () => {
+        dragging = true;
+    });
+
+    window.addEventListener('mousemove', (e) => {
+        if (dragging) {
+            const x = e.clientX - joystickRect.left - joystickRect.width / 2;
+            const y = e.clientY - joystickRect.top - joystickRect.height / 2;
+            const distance = Math.min(Math.sqrt(x * x + y * y), joystickRect.width / 2);
+            const angle = Math.atan2(y, x);
+
+            joystickHandle.style.left = `${joystickRect.width / 2 + Math.cos(angle) * distance - joystickHandle.offsetWidth / 2}px`;
+            joystickHandle.style.top = `${joystickRect.height / 2 + Math.sin(angle) * distance - joystickHandle.offsetHeight / 2}px`;
+
+            const mobileInputSystem = game.engine.getSystem('MobileInputSystem');
+            mobileInputSystem.inputs.pan.x = (Math.cos(angle) * distance) * 2;
+            mobileInputSystem.inputs.pan.y = (Math.sin(angle) * distance) * 2;
+        }
+    });
+
+    window.addEventListener('mouseup', () => {
+        dragging = false;
+        joystickHandle.style.left = `${joystickRect.width / 2 - joystickHandle.offsetWidth / 2}px`;
+        joystickHandle.style.top = `${joystickRect.height / 2 - joystickHandle.offsetHeight / 2}px`;
+        const mobileInputSystem = game.engine.getSystem('MobileInputSystem');
+        mobileInputSystem.inputs.pan.x = 0;
+        mobileInputSystem.inputs.pan.y = 0;
+    });
+
+    const jumpButton = document.getElementById('jump-button');
+    jumpButton.addEventListener('mousedown', () => {
+        const mobileInputSystem = game.engine.getSystem('MobileInputSystem');
+        mobileInputSystem.inputs.jump = true;
+    });
+
+    jumpButton.addEventListener('mouseup', () => {
+        const mobileInputSystem = game.engine.getSystem('MobileInputSystem');
+        mobileInputSystem.inputs.jump = false;
+    });
     
     // Add some debug info to the page
     const info = document.createElement('div');


### PR DESCRIPTION
This commit upgrades the demo to use mobile input by:

- Adding a visual joystick to the screen.
- Connecting the joystick to the `MobileInputSystem` to control the player's movement.
- Adding a jump button to the screen.
- Connecting the jump button to the `MobileInputSystem` to make the player jump.